### PR TITLE
sidemenu 컴포넌트의 로고 하단 보더와 우측의 보더를 제거

### DIFF
--- a/src/components/SideMenu/SideMenu.module.css
+++ b/src/components/SideMenu/SideMenu.module.css
@@ -6,14 +6,14 @@
   width: 300px;
   height: 100vh;
   background-color: var(--white-ffffff);
-  border-right: 1px solid var(--gray-d9d9d9);
+  /* border-right: 1px solid var(--gray-d9d9d9); */
   overflow: hidden;
 }
 
 /* ========== 상단: Logo ========== */
 .logoArea {
   padding: 20px 24px;
-  border-bottom: 1px solid var(--gray-d9d9d9);
+  /* border-bottom: 1px solid var(--gray-d9d9d9); */
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

sidemenu의 로고 하단부분과 우측 보더를 주석 처리를 통해서 제거 했습니다.(figma시안을 충족하기 위해서) 

<img width="727" height="1476" alt="스크린샷 2026-01-06 152829" src="https://github.com/user-attachments/assets/d29cf5ac-559c-474d-90e9-2cf3942cec46" />


<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **스타일**
  * 사이드 메뉴의 활성 상태 테두리가 제거되어 인터페이스가 더욱 깔끔해졌습니다.
  * 로고 영역의 하단 테두리도 함께 제거되어 전체적인 시각 디자인이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->